### PR TITLE
fix(applyTags): update `options` key from apply_tags to applyTags

### DIFF
--- a/arrapi/objs.py
+++ b/arrapi/objs.py
@@ -459,7 +459,7 @@ class Movie(BaseArr):
         valid_move_files = options["path"] if "path" in options else False
         for key, value in options.items():
             if key == "tags":
-                tag_type = options["apply_tags"]
+                tag_type = options["applyTags"]
                 if tag_type == "add":
                     self._data[key].extend([t for t in value if t not in self._data["tags"]])
                 elif tag_type == "remove":
@@ -705,7 +705,7 @@ class Series(BaseArr):
         valid_move_files = options["path"] if "path" in options else False
         for key, value in options.items():
             if key == "tags":
-                tag_type = options["apply_tags"]
+                tag_type = options["applyTags"]
                 if tag_type == "add":
                     self._data[key].extend([t for t in value if t not in self._data["tags"]])
                 elif tag_type == "remove":


### PR DESCRIPTION
## Description

Fix `options` key name for `applyTags` to match what is being set.  See #3 for details.

### Issues Fixed or Closed

- Fixes #3 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
