### PR TITLE
Move to importlib

### DIFF
--- a/arrapi/__init__.py
+++ b/arrapi/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib.metadata import version
 
 from .exceptions import ArrException, ConnectionFailure, Excluded, Exists, Invalid, NotFound, Unauthorized
 from .objs.simple import MetadataProfile, RemotePathMapping, RootFolder, UnmappedFolder, Season
@@ -9,8 +9,8 @@ from .apis.lidarr import LidarrAPI
 from .apis.readarr import ReadarrAPI
 
 try:
-    __version__ = pkg_resources.get_distribution("arrapi").version
-except pkg_resources.DistributionNotFound:
+    __version__ =  version("arrapi")
+except importlib.metadata.PackageNotFoundError::
     __version__ = ""
 __author__ = "Nathan Taggart"
 __credits__ = "meisnate12"

--- a/arrapi/__init__.py
+++ b/arrapi/__init__.py
@@ -10,7 +10,7 @@ from .apis.readarr import ReadarrAPI
 
 try:
     __version__ = version("arrapi")
-except importlib.metadata.PackageNotFoundError::
+except importlib.metadata.PackageNotFoundError:
     __version__ = ""
 __author__ = "Nathan Taggart"
 __credits__ = "meisnate12"

--- a/arrapi/__init__.py
+++ b/arrapi/__init__.py
@@ -9,7 +9,7 @@ from .apis.lidarr import LidarrAPI
 from .apis.readarr import ReadarrAPI
 
 try:
-    __version__ =  version("arrapi")
+    __version__ = version("arrapi")
 except importlib.metadata.PackageNotFoundError::
     __version__ = ""
 __author__ = "Nathan Taggart"


### PR DESCRIPTION
## Description

Move off pkg_resources to eliminate:
```
/home/chaz/kometa/.direnv/python-3.12.6/lib/python3.12/site-packages/arrapi/__init__.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```

### Issues Fixed or Closed

- Fixes #20 

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
