### PR TITLE
Add support for paginated `ImportListExclusion`

### DIFF
--- a/arrapi/apis/radarr.py
+++ b/arrapi/apis/radarr.py
@@ -98,7 +98,7 @@ class RadarrAPI(BaseAPI):
 
     def respect_list_exclusions_when_adding(self):
         """ Stores all List Exclusions so whenever :func:`~arrapi.objs.reload.Movie.add` or :func:`~arrapi.apis.sonarr.RadarrAPI.add_multiple_movies` is called the additions will be checked against the Exclusion List  """
-        self.exclusions = [RadarrExclusion(self, ex).tmdbId for ex in self._raw.get_exclusions()]
+        self.exclusions = [ex.tmdbId for ex in RadarrExclusion.all(self)]
 
     def get_movie(self, movie_id: Optional[int] = None, tmdb_id: Optional[int] = None, imdb_id: Optional[str] = None) -> Movie:
         """ Gets a :class:`~arrapi.objs.reload.Movie` by one of the IDs.

--- a/arrapi/apis/radarr.py
+++ b/arrapi/apis/radarr.py
@@ -98,7 +98,7 @@ class RadarrAPI(BaseAPI):
 
     def respect_list_exclusions_when_adding(self):
         """ Stores all List Exclusions so whenever :func:`~arrapi.objs.reload.Movie.add` or :func:`~arrapi.apis.sonarr.RadarrAPI.add_multiple_movies` is called the additions will be checked against the Exclusion List  """
-        self.exclusions = [ex.tmdbId for ex in RadarrExclusion.all(self)]
+        self.exclusions = [ex.tmdbId for ex in RadarrExclusion.get_all(self)]
 
     def get_movie(self, movie_id: Optional[int] = None, tmdb_id: Optional[int] = None, imdb_id: Optional[str] = None) -> Movie:
         """ Gets a :class:`~arrapi.objs.reload.Movie` by one of the IDs.

--- a/arrapi/apis/sonarr.py
+++ b/arrapi/apis/sonarr.py
@@ -108,7 +108,7 @@ class SonarrAPI(BaseAPI):
 
     def respect_list_exclusions_when_adding(self):
         """ Stores all List Exclusions so whenever :func:`~arrapi.objs.reload.Series.add` or :func:`~arrapi.apis.sonarr.SonarrAPI.add_multiple_series` is called the additions will be checked against the Exclusion List  """
-        self.exclusions = [SonarrExclusion(self, ex).tvdbId for ex in self._raw.get_importlistexclusion()]
+        self.exclusions = [ex.tvdbId for ex in SonarrExclusion.get_all(self)]
 
     def get_series(self, series_id: Optional[int] = None, tvdb_id: Optional[int] = None) -> Series:
         """ Gets a :class:`~arrapi.objs.reload.Series` by one of the IDs.

--- a/arrapi/objs/simple.py
+++ b/arrapi/objs/simple.py
@@ -169,6 +169,26 @@ class RadarrExclusion(SimpleObj):
             year (int): Year of the Excluded Movie.
     """
 
+    @classmethod
+    def all(cls, arr):
+        if not arr._raw.new_codebase:
+            return [cls(arr, data) for data in arr._raw.get_exclusions()]
+
+        page = 1
+        page_size = 250
+        exclusions = []
+        while True:
+            response = arr._raw.get_exclusions_paged(page=page, pageSize=page_size)
+            records = response.get("records", [])
+            exclusions.extend(cls(arr, data) for data in records)
+            total_records = response.get("totalRecords")
+            if total_records is not None:
+                if len(exclusions) >= total_records:
+                    return exclusions
+            elif len(records) < page_size:
+                return exclusions
+            page += 1
+
     def _load(self, data):
         super()._load(data)
         self.tmdbId = self._parse(attrs="tmdbId", value_type="int")

--- a/arrapi/objs/simple.py
+++ b/arrapi/objs/simple.py
@@ -2,6 +2,43 @@ from abc import abstractmethod
 
 from arrapi.objs.base import BaseObj
 
+_DEFAULT_PAGE_SIZE = 250
+
+
+def _paginate(arr, paged_getter, page_size=_DEFAULT_PAGE_SIZE):
+    """ Walk a Sonarr/Radarr ``*/paged`` endpoint until exhausted.
+
+        The endpoint returns a JSON body shaped ``{"records": [...], "totalRecords": N, ...}``.
+        We prefer ``totalRecords`` when the server sends it and fall back to a short-page
+        heuristic (a page smaller than ``page_size`` implies we've reached the end) otherwise.
+
+        Parameters:
+            arr: The API wrapper (used only for logging context; unused here today but
+                kept in the signature so callers pass an unambiguous handle).
+            paged_getter (Callable[[int, int], dict]): Function accepting
+                ``(page, pageSize)`` and returning the raw JSON dict.
+            page_size (int): Page size to request from the server.
+
+        Yields:
+            dict: Each raw record dict, exactly as returned by the server.
+    """
+    page = 1
+    seen = 0
+    while True:
+        response = paged_getter(page=page, pageSize=page_size) or {}
+        records = response.get("records", [])
+        for record in records:
+            yield record
+        seen += len(records)
+        total_records = response.get("totalRecords")
+        if total_records is not None:
+            if seen >= total_records:
+                return
+        elif len(records) < page_size:
+            return
+        page += 1
+
+
 class SimpleObj(BaseObj):
     @abstractmethod
     def _load(self, data):
@@ -170,24 +207,22 @@ class RadarrExclusion(SimpleObj):
     """
 
     @classmethod
-    def all(cls, arr):
+    def get_all(cls, arr):
+        """ Return every Radarr Import List Exclusion.
+
+            On the modern (v3+) codebase this pages through ``/api/v3/exclusions/paged``
+            because the flat ``/api/v3/exclusions`` endpoint is marked ``[Obsolete]``
+            upstream. On the legacy codebase it falls back to the flat endpoint.
+
+            Parameters:
+                arr (RadarrAPI): The Radarr API wrapper to load exclusions from.
+
+            Returns:
+                List[RadarrExclusion]: Every exclusion currently stored in Radarr.
+        """
         if not arr._raw.new_codebase:
             return [cls(arr, data) for data in arr._raw.get_exclusions()]
-
-        page = 1
-        page_size = 250
-        exclusions = []
-        while True:
-            response = arr._raw.get_exclusions_paged(page=page, pageSize=page_size)
-            records = response.get("records", [])
-            exclusions.extend(cls(arr, data) for data in records)
-            total_records = response.get("totalRecords")
-            if total_records is not None:
-                if len(exclusions) >= total_records:
-                    return exclusions
-            elif len(records) < page_size:
-                return exclusions
-            page += 1
+        return [cls(arr, data) for data in _paginate(arr, arr._raw.get_exclusions_paged)]
 
     def _load(self, data):
         super()._load(data)
@@ -203,6 +238,25 @@ class SonarrExclusion(SimpleObj):
             tvdbId (int): TVDb ID of the Excluded Series.
             title (str): Title of the Excluded Series.
     """
+
+    @classmethod
+    def get_all(cls, arr):
+        """ Return every Sonarr Import List Exclusion.
+
+            On the modern (v3+) codebase this pages through
+            ``/api/v3/importlistexclusion/paged`` because the flat endpoint is marked
+            ``[Obsolete]`` upstream. On the legacy codebase it falls back to the flat
+            endpoint.
+
+            Parameters:
+                arr (SonarrAPI): The Sonarr API wrapper to load exclusions from.
+
+            Returns:
+                List[SonarrExclusion]: Every exclusion currently stored in Sonarr.
+        """
+        if not arr._raw.new_codebase:
+            return [cls(arr, data) for data in arr._raw.get_importlistexclusion()]
+        return [cls(arr, data) for data in _paginate(arr, arr._raw.get_importlistexclusion_paged)]
 
     def _load(self, data):
         super()._load(data)

--- a/arrapi/raws/radarr.py
+++ b/arrapi/raws/radarr.py
@@ -58,8 +58,24 @@ class RadarrRawAPI(BaseRawAPI):
         return self._get("movie/lookup", **{"term": term})
 
     def get_exclusions(self):
-        """ GET /exclusions """
-        return self._get("exclusions")
+        """ GET /exclusions/paged """
+        if not self.new_codebase:
+            return self._get("exclusions")
+
+        page = 1
+        page_size = 250
+        records = []
+        while True:
+            response = self._get("exclusions/paged", page=page, pageSize=page_size)
+            page_records = response.get("records", [])
+            records.extend(page_records)
+            total_records = response.get("totalRecords")
+            if total_records is not None:
+                if len(records) >= total_records:
+                    return records
+            elif len(page_records) < page_size:
+                return records
+            page += 1
 
     def post_exclusions(self, json):
         """ POST /exclusions """

--- a/arrapi/raws/radarr.py
+++ b/arrapi/raws/radarr.py
@@ -58,24 +58,17 @@ class RadarrRawAPI(BaseRawAPI):
         return self._get("movie/lookup", **{"term": term})
 
     def get_exclusions(self):
-        """ GET /exclusions/paged """
-        if not self.new_codebase:
-            return self._get("exclusions")
+        """ GET /exclusions """
+        return self._get("exclusions")
 
-        page = 1
-        page_size = 250
-        records = []
-        while True:
-            response = self._get("exclusions/paged", page=page, pageSize=page_size)
-            page_records = response.get("records", [])
-            records.extend(page_records)
-            total_records = response.get("totalRecords")
-            if total_records is not None:
-                if len(records) >= total_records:
-                    return records
-            elif len(page_records) < page_size:
-                return records
-            page += 1
+    def get_exclusions_paged(self, page=1, pageSize=10, sortKey=None, sortDirection=None):
+        """ GET /exclusions/paged """
+        params = {"page": page, "pageSize": pageSize}
+        if sortKey is not None:
+            params["sortKey"] = sortKey
+        if sortDirection is not None:
+            params["sortDirection"] = sortDirection
+        return self._get("exclusions/paged", **params)
 
     def post_exclusions(self, json):
         """ POST /exclusions """

--- a/arrapi/raws/radarr.py
+++ b/arrapi/raws/radarr.py
@@ -61,7 +61,7 @@ class RadarrRawAPI(BaseRawAPI):
         """ GET /exclusions """
         return self._get("exclusions")
 
-    def get_exclusions_paged(self, page=1, pageSize=10, sortKey=None, sortDirection=None):
+    def get_exclusions_paged(self, page=1, pageSize=250, sortKey=None, sortDirection=None):
         """ GET /exclusions/paged """
         params = {"page": page, "pageSize": pageSize}
         if sortKey is not None:

--- a/arrapi/raws/sonarr.py
+++ b/arrapi/raws/sonarr.py
@@ -84,6 +84,15 @@ class SonarrRawAPI(BaseRawAPI):
         """ GET /importlistexclusion """
         return self._get("importlistexclusion")
 
+    def get_importlistexclusion_paged(self, page=1, pageSize=250, sortKey=None, sortDirection=None):
+        """ GET /importlistexclusion/paged """
+        params = {"page": page, "pageSize": pageSize}
+        if sortKey is not None:
+            params["sortKey"] = sortKey
+        if sortDirection is not None:
+            params["sortDirection"] = sortDirection
+        return self._get("importlistexclusion/paged", **params)
+
     def post_importlistexclusion(self, json):
         """ POST /importlistexclusion """
         return self._post("importlistexclusion", json=json)

--- a/tests/test_exclusions.py
+++ b/tests/test_exclusions.py
@@ -1,0 +1,119 @@
+"""Unit tests for the paginated Import List Exclusion loading logic.
+
+These tests intentionally avoid touching the network — the whole point of
+`RadarrExclusion.get_all` / `SonarrExclusion.get_all` is the pagination glue
+around the raw HTTP calls, so we mock those out and exercise the glue.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from arrapi.objs.simple import RadarrExclusion, SonarrExclusion, _paginate
+
+
+def _fake_arr(raw):
+    """Build the minimum surface `SimpleObj` needs: ``arr._raw`` and ``arr._raw``.
+
+    ``BaseObj.__init__`` does ``self._raw = arr._raw`` and then calls ``_load(data)``,
+    so we only need ``._raw`` on the fake arr. Both raw stubs must expose whatever
+    method the ``get_all`` classmethod reaches for.
+    """
+    return SimpleNamespace(_raw=raw)
+
+
+class PaginateHelperTests(unittest.TestCase):
+    def test_stops_when_totalRecords_reached(self):
+        pages = [
+            {"records": [{"tmdbId": 1}, {"tmdbId": 2}], "totalRecords": 3},
+            {"records": [{"tmdbId": 3}], "totalRecords": 3},
+        ]
+        getter = MagicMock(side_effect=pages)
+        result = list(_paginate(arr=None, paged_getter=getter, page_size=2))
+        self.assertEqual([r["tmdbId"] for r in result], [1, 2, 3])
+        self.assertEqual(getter.call_count, 2)
+        getter.assert_any_call(page=1, pageSize=2)
+        getter.assert_any_call(page=2, pageSize=2)
+
+    def test_stops_on_short_page_when_totalRecords_missing(self):
+        pages = [
+            {"records": [{"tmdbId": 1}, {"tmdbId": 2}]},
+            {"records": [{"tmdbId": 3}]},  # short page -> stop
+        ]
+        getter = MagicMock(side_effect=pages)
+        result = list(_paginate(arr=None, paged_getter=getter, page_size=2))
+        self.assertEqual([r["tmdbId"] for r in result], [1, 2, 3])
+        self.assertEqual(getter.call_count, 2)
+
+    def test_handles_empty_first_page(self):
+        getter = MagicMock(return_value={"records": [], "totalRecords": 0})
+        self.assertEqual(list(_paginate(arr=None, paged_getter=getter, page_size=10)), [])
+        self.assertEqual(getter.call_count, 1)
+
+    def test_handles_none_response(self):
+        # Some Arr error paths return None from _get.
+        getter = MagicMock(return_value=None)
+        self.assertEqual(list(_paginate(arr=None, paged_getter=getter, page_size=10)), [])
+        self.assertEqual(getter.call_count, 1)
+
+
+class RadarrExclusionGetAllTests(unittest.TestCase):
+    def test_new_codebase_uses_paged_endpoint(self):
+        raw = MagicMock()
+        raw.new_codebase = True
+        raw.get_exclusions_paged.side_effect = [
+            {"records": [
+                {"tmdbId": 11, "movieTitle": "Star Wars", "movieYear": 1977},
+                {"tmdbId": 1891, "movieTitle": "The Empire Strikes Back", "movieYear": 1980},
+            ], "totalRecords": 2},
+        ]
+        exclusions = RadarrExclusion.get_all(_fake_arr(raw))
+        self.assertEqual([e.tmdbId for e in exclusions], [11, 1891])
+        self.assertEqual([e.title for e in exclusions], ["Star Wars", "The Empire Strikes Back"])
+        raw.get_exclusions.assert_not_called()
+        raw.get_exclusions_paged.assert_called_once_with(page=1, pageSize=250)
+
+    def test_legacy_codebase_uses_flat_endpoint(self):
+        raw = MagicMock()
+        raw.new_codebase = False
+        raw.get_exclusions.return_value = [
+            {"tmdbId": 1, "movieTitle": "Old", "movieYear": 1999},
+        ]
+        exclusions = RadarrExclusion.get_all(_fake_arr(raw))
+        self.assertEqual([e.tmdbId for e in exclusions], [1])
+        raw.get_exclusions_paged.assert_not_called()
+        raw.get_exclusions.assert_called_once_with()
+
+
+class SonarrExclusionGetAllTests(unittest.TestCase):
+    def test_new_codebase_uses_paged_endpoint(self):
+        raw = MagicMock()
+        raw.new_codebase = True
+        raw.get_importlistexclusion_paged.side_effect = [
+            {"records": [
+                {"tvdbId": 100, "title": "Breaking Bad"},
+                {"tvdbId": 200, "title": "The Wire"},
+            ], "totalRecords": 3},
+            {"records": [
+                {"tvdbId": 300, "title": "Firefly"},
+            ], "totalRecords": 3},
+        ]
+        exclusions = SonarrExclusion.get_all(_fake_arr(raw))
+        self.assertEqual([e.tvdbId for e in exclusions], [100, 200, 300])
+        raw.get_importlistexclusion.assert_not_called()
+        self.assertEqual(raw.get_importlistexclusion_paged.call_count, 2)
+
+    def test_legacy_codebase_uses_flat_endpoint(self):
+        raw = MagicMock()
+        raw.new_codebase = False
+        raw.get_importlistexclusion.return_value = [
+            {"tvdbId": 42, "title": "HHGTTG"},
+        ]
+        exclusions = SonarrExclusion.get_all(_fake_arr(raw))
+        self.assertEqual([e.tvdbId for e in exclusions], [42])
+        raw.get_importlistexclusion_paged.assert_not_called()
+        raw.get_importlistexclusion.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Updates Radarr import list exclusion retrieval to use the current paginated `/api/v3/exclusions/paged` endpoint instead of the deprecated `/api/v3/exclusions` endpoint. The raw API method still returns a flat list of exclusions for existing callers.


### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas